### PR TITLE
add .PHONY

### DIFF
--- a/f19/10.2-makefiles/03_featureful_makefile/Makefile
+++ b/f19/10.2-makefiles/03_featureful_makefile/Makefile
@@ -41,3 +41,6 @@ diff:
 
 # include the dependencies
 -include $(DEPFILES)
+
+# add .PHONY so that the non-targetfile - rules work even if a file with the same name exists.
+.PHONY: all clean distribute diff


### PR DESCRIPTION
so that the non-targetfile - rules work even if a file with the same name exists.
Great lesson, i learned a lot! However I think .PHONY should be mentioned as well. 